### PR TITLE
fix: prevent operations on disposed VideoPlayerController instances

### DIFF
--- a/lib/src/video_player/video_player.dart
+++ b/lib/src/video_player/video_player.dart
@@ -568,6 +568,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// If [moment] is outside of the video's full range it will be automatically
   /// and silently clamped.
   Future<void> seekTo(Duration? position) async {
+    if (_isDisposed) return;
     _timer?.cancel();
     bool isPlaying = value.isPlaying;
     final int positionInMs = value.position.inMilliseconds;
@@ -599,6 +600,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   Future<void> cancelPendingSeek() async {
+    if (_isDisposed) return;
     await _videoPlayerPlatform.cancelPendingSeek(_textureId);
   }
 
@@ -631,6 +633,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   /// [height] specifies height of the selected track
   /// [bitrate] specifies bitrate of the selected track
   Future<void> setTrackParameters(int? width, int? height, int? bitrate) async {
+    if (_isDisposed) return;
     await _videoPlayerPlatform.setTrackParameters(
       _textureId,
       width,
@@ -645,6 +648,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
     double? width,
     double? height,
   }) async {
+    if (_isDisposed) return;
     await _videoPlayerPlatform.enablePictureInPicture(
       textureId,
       top,
@@ -655,6 +659,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   Future<void> disablePictureInPicture() async {
+    if (_isDisposed) return;
     await _videoPlayerPlatform.disablePictureInPicture(textureId);
   }
 
@@ -672,6 +677,7 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   Future<bool?> isPictureInPictureSupported() async {
+    if (_isDisposed) return false;
     if (_textureId == null) {
       return false;
     }
@@ -683,14 +689,17 @@ class VideoPlayerController extends ValueNotifier<VideoPlayerValue> {
   }
 
   void clear() {
+    if (_isDisposed) return;
     _videoPlayerPlatform.clear(_textureId);
   }
 
   void setAudioTrack(String? name, int? index) {
+    if (_isDisposed) return;
     _videoPlayerPlatform.setAudioTrack(_textureId, name, index);
   }
 
   void setMixWithOthers(bool mixWithOthers) {
+    if (_isDisposed) return;
     _videoPlayerPlatform.setMixWithOthers(_textureId, mixWithOthers);
   }
 


### PR DESCRIPTION
StandardMethodCodec.decodeEnvelope crash 수정

재현경로: 광고 노출 영상 진입 하자마자 이탈시 간헐적으로 발생