### PR TITLE
fix: 누락된 key 추가

### DIFF
--- a/lib/src/core/better_player.dart
+++ b/lib/src/core/better_player.dart
@@ -267,6 +267,7 @@ class _BetterPlayerState extends State<BetterPlayer>
       onVisibilityChanged: (VisibilityInfo info) =>
           widget.controller.onPlayerVisibilityChanged(info.visibleFraction),
       child: BetterPlayerWithControls(
+        key: Key("${widget.controller.hashCode}_key"),
         controller: widget.controller,
       ),
     );


### PR DESCRIPTION
- 일점사 개발 도중 발생한 **PlatformException(recreating_view) 에러로 동영상 재생 안되는 문제 해결** 합니다.
- 다른 재생이슈에서도 도움이 되길 기대합니다.