### PR TITLE
fix: 자막 파싱 시 Error 계열 예외를 못 잡아 앱이 크래시하던 문제 수정

### DIFF
--- a/lib/src/core/better_player_utils.dart
+++ b/lib/src/core/better_player_utils.dart
@@ -62,4 +62,23 @@ class BetterPlayerUtils {
       print(logMessage);
     }
   }
+
+  /// Logs a swallowed error and forwards it (with its stack trace) to the host
+  /// app's error handling (e.g. Sentry via [FlutterError.onError]) as a
+  /// non-fatal report, so the error stays visible without crashing the app.
+  static void logError(
+    String message,
+    Object error,
+    StackTrace stackTrace,
+  ) {
+    log("$message, error: $error");
+    FlutterError.reportError(
+      FlutterErrorDetails(
+        exception: error,
+        stack: stackTrace,
+        library: 'awesome_video_player',
+        context: ErrorDescription(message),
+      ),
+    );
+  }
 }

--- a/lib/src/subtitles/better_player_subtitle.dart
+++ b/lib/src/subtitles/better_player_subtitle.dart
@@ -31,7 +31,7 @@ class BetterPlayerSubtitle {
         return _handle3LinesAndMoreSubtitles(scanner, isWebVTT);
       }
       return BetterPlayerSubtitle._();
-    } catch (_) {
+    } on Exception catch (_) {
       BetterPlayerUtils.log("Failed to parse subtitle line: $value");
       return BetterPlayerSubtitle._();
     }
@@ -93,7 +93,7 @@ class BetterPlayerSubtitle {
         texts: texts,
         cueSettings: cueSettings,
       );
-    } catch (_) {
+    } on Exception catch (_) {
       BetterPlayerUtils.log("Failed to parse subtitle line: $scanner");
       return BetterPlayerSubtitle._();
     }
@@ -125,7 +125,7 @@ class BetterPlayerSubtitle {
           end: end,
           texts: texts,
           cueSettings: cueSettings);
-    } catch (_) {
+    } on Exception catch (_) {
       BetterPlayerUtils.log("Failed to parse subtitle line: $scanner");
       return BetterPlayerSubtitle._();
     }
@@ -163,7 +163,7 @@ class BetterPlayerSubtitle {
         milliseconds: int.tryParse(secsAndMillsSplit[1])!,
       );
       return result;
-    } catch (_) {
+    } on Exception catch (_) {
       BetterPlayerUtils.log("Failed to process value: $value");
       return const Duration();
     }

--- a/lib/src/subtitles/better_player_subtitle.dart
+++ b/lib/src/subtitles/better_player_subtitle.dart
@@ -31,7 +31,7 @@ class BetterPlayerSubtitle {
         return _handle3LinesAndMoreSubtitles(scanner, isWebVTT);
       }
       return BetterPlayerSubtitle._();
-    } on Exception catch (_) {
+    } catch (_) {
       BetterPlayerUtils.log("Failed to parse subtitle line: $value");
       return BetterPlayerSubtitle._();
     }
@@ -93,7 +93,7 @@ class BetterPlayerSubtitle {
         texts: texts,
         cueSettings: cueSettings,
       );
-    } on Exception catch (_) {
+    } catch (_) {
       BetterPlayerUtils.log("Failed to parse subtitle line: $scanner");
       return BetterPlayerSubtitle._();
     }
@@ -125,7 +125,7 @@ class BetterPlayerSubtitle {
           end: end,
           texts: texts,
           cueSettings: cueSettings);
-    } on Exception catch (_) {
+    } catch (_) {
       BetterPlayerUtils.log("Failed to parse subtitle line: $scanner");
       return BetterPlayerSubtitle._();
     }
@@ -163,7 +163,7 @@ class BetterPlayerSubtitle {
         milliseconds: int.tryParse(secsAndMillsSplit[1])!,
       );
       return result;
-    } on Exception catch (_) {
+    } catch (_) {
       BetterPlayerUtils.log("Failed to process value: $value");
       return const Duration();
     }

--- a/lib/src/subtitles/better_player_subtitle.dart
+++ b/lib/src/subtitles/better_player_subtitle.dart
@@ -114,6 +114,18 @@ class BetterPlayerSubtitle {
         firstLineOfText = 2;
       }
 
+      // The timing line is not in the expected '<start> --> <end>' format, so
+      // timeSplit has no end part. Report it (keeps it visible in Sentry) and
+      // skip this cue instead of accessing timeSplit[1] out of range.
+      if (timeSplit.length < 2) {
+        BetterPlayerUtils.logError(
+          "Failed to parse subtitle line: $scanner",
+          FormatException("Missing '$timerSeparator' in timing line", scanner),
+          StackTrace.current,
+        );
+        return BetterPlayerSubtitle._();
+      }
+
       final start = _stringToDuration(timeSplit[0]);
       final endWithSettings = timeSplit[1];
       final cueSettings = _parseCueSettings(endWithSettings);


### PR DESCRIPTION
[Sentry issue](https://ridi.sentry.io/issues/7603183119/?project=4508080008790016&query=is%3Aunresolved&referrer=issue-stream)

와 같이 최근 推しのち上司、に溺愛されて(ObsessBoss, JP-6003) 작품 업로드 후
`ArgumentError: RangeError (length): Invalid value: Only valid value is 0: 1` 에러가 발생하는 것이 확인되었습니다.

세부 코드위치 확인 결과 [better_player_subtitle.dart:31](https://github.com/ridiplay2/awesome_video_player/blob/50d1adf6e77fd7fbe5514f5c8e6d68e849cb3b3d/lib/src/subtitles/better_player_subtitle.dart#L102) 에서 `timerSeparator = ' --> '` 기준으로  split하도록 설정되어있어, 자막에 `' --> '`가 없다면 `[1]` 인덱스 위치가 없어 에러가 발생합니다.

위 에러에 대한 처리가 없어 `Error`로 잡히게 되어 앱 크래시가 발생하는데, 앱이 꺼지기보다는 자막이 없더라도 일단은 재생되어야하지 않나 생각되어 Error 가 발생했을때는 기본적으로 빈자막이 표시되도록 설정하였습니다.

위 작품의 시청기록을 보면 전체 시청자 6,344명 최종화 완독자 1,070명(16.9%)로 특정 사용자에게만 발생하는 것 같은데, 에러발생 user수가 545로 적지는 않아서 어떤자막인지도 확인이 필요해보입니다.